### PR TITLE
Added weakly connected components

### DIFF
--- a/src/dachshund/connected_components.rs
+++ b/src/dachshund/connected_components.rs
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 use crate::dachshund::graph_base::GraphBase;
+use crate::dachshund::simple_undirected_graph::UndirectedGraph;
+use crate::dachshund::simple_directed_graph::DirectedGraph;
 use crate::dachshund::id_types::NodeId;
 use crate::dachshund::node::{NodeBase, NodeEdgeBase};
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -78,7 +80,21 @@ pub trait ConnectedComponents: GraphBase {
         }
         v
     }
+}
+
+pub trait ConnectedComponentsUndirected: GraphBase
+where
+    Self: ConnectedComponents,
+    Self: UndirectedGraph {
     fn get_connected_components(&self) -> Vec<Vec<NodeId>> {
+        self._get_connected_components(None, None)
+    }
+}
+pub trait ConnectedComponentsDirected: GraphBase
+where
+    Self: ConnectedComponents,
+    Self: DirectedGraph {
+    fn get_weakly_connected_components(&self) -> Vec<Vec<NodeId>> {
         self._get_connected_components(None, None)
     }
 }

--- a/src/dachshund/simple_directed_graph.rs
+++ b/src/dachshund/simple_directed_graph.rs
@@ -10,7 +10,13 @@ use crate::dachshund::id_types::NodeId;
 use crate::dachshund::node::{NodeBase, SimpleDirectedNode};
 use std::collections::hash_map::{Keys, Values};
 use std::collections::HashMap;
+use crate::dachshund::connected_components::{
+  ConnectedComponents, ConnectedComponentsDirected
+};
 
+pub trait DirectedGraph
+where Self: GraphBase  
+{}
 pub struct SimpleDirectedGraph {
     pub nodes: HashMap<NodeId, SimpleDirectedNode>,
     pub ids: Vec<NodeId>,
@@ -53,4 +59,7 @@ impl GraphBase for SimpleDirectedGraph {
         self.nodes.len()
     }
 }
+impl DirectedGraph for SimpleDirectedGraph {}
 impl Brokerage for SimpleDirectedGraph {}
+impl ConnectedComponents for SimpleDirectedGraph {}
+impl ConnectedComponentsDirected for SimpleDirectedGraph {}

--- a/src/dachshund/simple_transformer.rs
+++ b/src/dachshund/simple_transformer.rs
@@ -9,7 +9,7 @@ extern crate serde_json;
 
 use crate::dachshund::betweenness::Betweenness;
 use crate::dachshund::clustering::Clustering;
-use crate::dachshund::connected_components::ConnectedComponents;
+use crate::dachshund::connected_components::ConnectedComponentsUndirected;
 use crate::dachshund::coreness::Coreness;
 use crate::dachshund::eigenvector_centrality::EigenvectorCentrality;
 use crate::dachshund::error::CLQResult;

--- a/src/dachshund/simple_undirected_graph.rs
+++ b/src/dachshund/simple_undirected_graph.rs
@@ -9,7 +9,9 @@ use crate::dachshund::algebraic_connectivity::AlgebraicConnectivity;
 use crate::dachshund::betweenness::Betweenness;
 use crate::dachshund::clustering::Clustering;
 use crate::dachshund::cnm_communities::CNMCommunities;
-use crate::dachshund::connected_components::ConnectedComponents;
+use crate::dachshund::connected_components::{
+  ConnectedComponents, ConnectedComponentsUndirected
+};
 use crate::dachshund::connectivity::Connectivity;
 use crate::dachshund::coreness::Coreness;
 use crate::dachshund::eigenvector_centrality::EigenvectorCentrality;
@@ -22,6 +24,9 @@ use crate::dachshund::transitivity::Transitivity;
 use std::collections::hash_map::{Keys, Values};
 use std::collections::HashMap;
 
+pub trait UndirectedGraph
+where Self: GraphBase  
+{}
 /// Keeps track of a simple undirected graph, composed of nodes without any type information.
 pub struct SimpleUndirectedGraph {
     pub nodes: HashMap<NodeId, SimpleNode>,
@@ -91,9 +96,11 @@ impl SimpleUndirectedGraph {
         }
     }
 }
+impl UndirectedGraph for SimpleUndirectedGraph {}
 
 impl CNMCommunities for SimpleUndirectedGraph {}
 impl ConnectedComponents for SimpleUndirectedGraph {}
+impl ConnectedComponentsUndirected for SimpleUndirectedGraph {}
 impl Coreness for SimpleUndirectedGraph {}
 
 impl AdjacencyMatrix for SimpleUndirectedGraph {}

--- a/tests/karate_club.rs
+++ b/tests/karate_club.rs
@@ -14,7 +14,9 @@ use lib_dachshund::dachshund::betweenness::Betweenness;
 use lib_dachshund::dachshund::brokerage::Brokerage;
 use lib_dachshund::dachshund::clustering::Clustering;
 use lib_dachshund::dachshund::cnm_communities::CNMCommunities;
-use lib_dachshund::dachshund::connected_components::ConnectedComponents;
+use lib_dachshund::dachshund::connected_components::{
+    ConnectedComponentsDirected, ConnectedComponentsUndirected
+};
 use lib_dachshund::dachshund::connectivity::Connectivity;
 use lib_dachshund::dachshund::coreness::Coreness;
 use lib_dachshund::dachshund::eigenvector_centrality::EigenvectorCentrality;
@@ -535,4 +537,11 @@ fn test_brokerage() {
                    expected_counts[node_id.value() as usize].4);
         
     };
+}
+#[test]
+fn test_weakly_connected_components() {
+    let gd = get_directed_karate_club_graph(); 
+    let cc = gd.get_weakly_connected_components();
+    assert_eq!(cc[0].len(), 34);
+    assert_eq!(cc.len(), 1);
 }

--- a/tests/simple_graph.rs
+++ b/tests/simple_graph.rs
@@ -7,7 +7,9 @@
 extern crate lib_dachshund;
 use crate::lib_dachshund::TransformerBase;
 use lib_dachshund::dachshund::cnm_communities::CNMCommunities;
-use lib_dachshund::dachshund::connected_components::ConnectedComponents;
+use lib_dachshund::dachshund::connected_components::{
+    ConnectedComponentsUndirected, ConnectedComponents
+};
 use lib_dachshund::dachshund::coreness::Coreness;
 use lib_dachshund::dachshund::id_types::NodeId;
 use lib_dachshund::dachshund::input::Input;


### PR DESCRIPTION
Weakly connected components for `SimpleDirectedGraph` are nothing but regular connected components by another name. This PR shows how the same underlying code could be reused for two different graph classes, with slightly different behavior. Trait composition in its full glory! 