### PR TITLE
Connectivity directed

### DIFF
--- a/src/dachshund/betweenness.rs
+++ b/src/dachshund/betweenness.rs
@@ -5,12 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 use crate::dachshund::connectivity::Connectivity;
+use crate::dachshund::connectivity::ConnectivityUndirected;
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
 use crate::dachshund::shortest_paths::ShortestPaths;
+use crate::dachshund::simple_undirected_graph::UndirectedGraph;
 use std::collections::HashMap;
 
-pub trait Betweenness: GraphBase + Connectivity + ShortestPaths {
+pub trait Betweenness:
+    GraphBase + UndirectedGraph + Connectivity + ShortestPaths + ConnectivityUndirected
+{
     fn get_node_betweenness_starting_from_sources(
         &self,
         sources: &[NodeId],

--- a/src/dachshund/connected_components.rs
+++ b/src/dachshund/connected_components.rs
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 use crate::dachshund::graph_base::GraphBase;
-use crate::dachshund::simple_undirected_graph::UndirectedGraph;
-use crate::dachshund::simple_directed_graph::DirectedGraph;
 use crate::dachshund::id_types::NodeId;
 use crate::dachshund::node::{NodeBase, NodeEdgeBase};
+use crate::dachshund::simple_directed_graph::DirectedGraph;
+use crate::dachshund::simple_undirected_graph::UndirectedGraph;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::iter::FromIterator;
 
@@ -85,7 +85,8 @@ pub trait ConnectedComponents: GraphBase {
 pub trait ConnectedComponentsUndirected: GraphBase
 where
     Self: ConnectedComponents,
-    Self: UndirectedGraph {
+    Self: UndirectedGraph,
+{
     fn get_connected_components(&self) -> Vec<Vec<NodeId>> {
         self._get_connected_components(None, None)
     }
@@ -93,7 +94,8 @@ where
 pub trait ConnectedComponentsDirected: GraphBase
 where
     Self: ConnectedComponents,
-    Self: DirectedGraph {
+    Self: DirectedGraph,
+{
     fn get_weakly_connected_components(&self) -> Vec<Vec<NodeId>> {
         self._get_connected_components(None, None)
     }

--- a/src/dachshund/connectivity.rs
+++ b/src/dachshund/connectivity.rs
@@ -7,6 +7,7 @@
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
 use crate::dachshund::node::{NodeBase, NodeEdgeBase};
+use crate::dachshund::simple_directed_graph::DirectedGraph;
 use crate::dachshund::simple_undirected_graph::UndirectedGraph;
 use std::collections::BTreeSet;
 
@@ -60,6 +61,15 @@ where
     Self: UndirectedGraph,
 {
     fn get_is_connected(&self) -> Result<bool, &'static str> {
+        self._get_is_connected(Self::NodeType::get_edges)
+    }
+}
+pub trait ConnectivityDirected: GraphBase
+where
+    Self: Connectivity,
+    Self: DirectedGraph,
+{
+    fn get_is_weakly_connected(&self) -> Result<bool, &'static str> {
         self._get_is_connected(Self::NodeType::get_edges)
     }
 }

--- a/src/dachshund/connectivity.rs
+++ b/src/dachshund/connectivity.rs
@@ -7,18 +7,28 @@
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
 use crate::dachshund::node::{NodeBase, NodeEdgeBase};
+use crate::dachshund::simple_undirected_graph::UndirectedGraph;
 use std::collections::BTreeSet;
 
 type OrderedNodeSet = BTreeSet<NodeId>;
 
 pub trait Connectivity: GraphBase {
-    fn visit_nodes_from_root(&self, root: &NodeId, visited: &mut OrderedNodeSet) {
+    fn visit_nodes_from_root<'a>(
+        &'a self,
+        root: &NodeId,
+        visited: &mut OrderedNodeSet,
+        edge_fn: fn(
+            &'a Self::NodeType,
+        ) -> Box<
+            dyn Iterator<Item = &'a <<Self as GraphBase>::NodeType as NodeBase>::NodeEdgeType> + 'a,
+        >,
+    ) {
         let mut to_visit: Vec<NodeId> = Vec::new();
         to_visit.push(*root);
         while !to_visit.is_empty() {
             let node_id = to_visit.pop().unwrap();
             let node = &self.get_node(node_id);
-            for edge in node.get_edges() {
+            for edge in edge_fn(node) {
                 let neighbor_id = edge.get_neighbor_id();
                 if !visited.contains(&neighbor_id) {
                     to_visit.push(neighbor_id);
@@ -27,13 +37,29 @@ pub trait Connectivity: GraphBase {
             visited.insert(node_id);
         }
     }
-    fn get_is_connected(&self) -> Result<bool, &'static str> {
+    fn _get_is_connected<'a>(
+        &'a self,
+        edge_fn: fn(
+            &'a Self::NodeType,
+        ) -> Box<
+            dyn Iterator<Item = &'a <<Self as GraphBase>::NodeType as NodeBase>::NodeEdgeType> + 'a,
+        >,
+    ) -> Result<bool, &'static str> {
         let mut visited: OrderedNodeSet = BTreeSet::new();
         if self.count_nodes() == 0 {
             return Err("Graph is empty");
         }
         let root = self.get_ids_iter().next().unwrap();
-        self.visit_nodes_from_root(&root, &mut visited);
+        self.visit_nodes_from_root(&root, &mut visited, edge_fn);
         Ok(visited.len() == self.count_nodes())
+    }
+}
+pub trait ConnectivityUndirected: GraphBase
+where
+    Self: Connectivity,
+    Self: UndirectedGraph,
+{
+    fn get_is_connected(&self) -> Result<bool, &'static str> {
+        self._get_is_connected(Self::NodeType::get_edges)
     }
 }

--- a/src/dachshund/graph_base.rs
+++ b/src/dachshund/graph_base.rs
@@ -28,6 +28,7 @@ where
     fn get_node(&self, node_id: NodeId) -> &Self::NodeType;
     fn count_edges(&self) -> usize;
     fn count_nodes(&self) -> usize;
+    fn create_empty() -> Self;
 
     fn get_ordered_node_ids(&self) -> Vec<NodeId> {
         let mut node_ids: Vec<NodeId> = self.get_ids_iter().cloned().collect();

--- a/src/dachshund/graph_builder_base.rs
+++ b/src/dachshund/graph_builder_base.rs
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+use crate::dachshund::graph_base::GraphBase;
+pub trait GraphBuilderBase
+where
+    Self: Sized,
+    Self::GraphType: GraphBase
+{
+    type GraphType;
+
+    fn from_vector(data: &Vec<(i64, i64)>) -> Self::GraphType;
+}
+

--- a/src/dachshund/mod.rs
+++ b/src/dachshund/mod.rs
@@ -19,6 +19,7 @@ pub mod eigenvector_centrality;
 pub mod error;
 pub mod graph_base;
 pub mod graph_builder;
+pub mod graph_builder_base;
 pub mod id_types;
 pub mod input;
 pub mod laplacian;

--- a/src/dachshund/node.rs
+++ b/src/dachshund/node.rs
@@ -49,7 +49,10 @@ where
     type NodeEdgeType: NodeEdgeBase + Sized;
 
     fn get_id(&self) -> NodeId;
+    // used to return *all* edges
     fn get_edges(&self) -> Box<dyn Iterator<Item = &Self::NodeEdgeType> + '_>;
+    // used to return *outgoing* edges only (to perform a traversal)
+    fn get_outgoing_edges(&self) -> Box<dyn Iterator<Item = &Self::NodeEdgeType> + '_>;
     fn degree(&self) -> usize;
     fn count_ties_with_ids(&self, ids: &HashSet<NodeId>) -> usize;
 }
@@ -82,6 +85,9 @@ impl NodeBase for Node {
     }
     fn get_edges(&self) -> Box<dyn Iterator<Item = &NodeEdge> + '_> {
         Box::new(self.edges.iter())
+    }
+    fn get_outgoing_edges(&self) -> Box<dyn Iterator<Item = &NodeEdge> + '_> {
+        self.get_edges()
     }
     /// degree is the edge count (in an unweighted graph)
     fn degree(&self) -> usize {
@@ -164,6 +170,9 @@ impl NodeBase for SimpleNode {
     fn get_edges(&self) -> Box<dyn Iterator<Item = &NodeId> + '_> {
         Box::new(self.neighbors.iter())
     }
+    fn get_outgoing_edges(&self) -> Box<dyn Iterator<Item = &NodeId> + '_> {
+        self.get_edges()
+    }
     /// degree is the edge count (in an unweighted graph)
     fn degree(&self) -> usize {
         self.neighbors.len()
@@ -222,6 +231,9 @@ impl NodeBase for SimpleDirectedNode {
     }
     fn get_edges(&self) -> Box<dyn Iterator<Item = &NodeId> + '_> {
         Box::new(self.in_neighbors.iter().chain(self.out_neighbors.iter()))
+    }
+    fn get_outgoing_edges(&self) -> Box<dyn Iterator<Item = &NodeId> + '_> {
+        self.get_edges()
     }
     /// degree is the edge count (in an unweighted graph)
     fn degree(&self) -> usize {

--- a/src/dachshund/simple_directed_graph.rs
+++ b/src/dachshund/simple_directed_graph.rs
@@ -5,18 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 use crate::dachshund::brokerage::Brokerage;
+use crate::dachshund::connected_components::{ConnectedComponents, ConnectedComponentsDirected};
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
 use crate::dachshund::node::{NodeBase, SimpleDirectedNode};
 use std::collections::hash_map::{Keys, Values};
 use std::collections::HashMap;
-use crate::dachshund::connected_components::{
-  ConnectedComponents, ConnectedComponentsDirected
-};
 
 pub trait DirectedGraph
-where Self: GraphBase  
-{}
+where
+    Self: GraphBase,
+{
+}
 pub struct SimpleDirectedGraph {
     pub nodes: HashMap<NodeId, SimpleDirectedNode>,
     pub ids: Vec<NodeId>,

--- a/src/dachshund/simple_directed_graph.rs
+++ b/src/dachshund/simple_directed_graph.rs
@@ -6,6 +6,7 @@
  */
 use crate::dachshund::brokerage::Brokerage;
 use crate::dachshund::connected_components::{ConnectedComponents, ConnectedComponentsDirected};
+use crate::dachshund::connectivity::{Connectivity, ConnectivityDirected};
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
 use crate::dachshund::node::{NodeBase, SimpleDirectedNode};
@@ -58,8 +59,16 @@ impl GraphBase for SimpleDirectedGraph {
     fn count_nodes(&self) -> usize {
         self.nodes.len()
     }
+    fn create_empty() -> Self {
+        SimpleDirectedGraph {
+            nodes: HashMap::new(),
+            ids: Vec::new(),
+        }
+    }
 }
 impl DirectedGraph for SimpleDirectedGraph {}
 impl Brokerage for SimpleDirectedGraph {}
 impl ConnectedComponents for SimpleDirectedGraph {}
 impl ConnectedComponentsDirected for SimpleDirectedGraph {}
+impl Connectivity for SimpleDirectedGraph {}
+impl ConnectivityDirected for SimpleDirectedGraph {}

--- a/src/dachshund/simple_directed_graph_builder.rs
+++ b/src/dachshund/simple_directed_graph_builder.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 extern crate nalgebra as na;
+use crate::dachshund::graph_builder_base::GraphBuilderBase;
 use crate::dachshund::id_types::NodeId;
 use crate::dachshund::node::SimpleDirectedNode;
 use crate::dachshund::simple_directed_graph::SimpleDirectedGraph;
@@ -12,10 +13,12 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 pub struct SimpleDirectedGraphBuilder {}
 
-impl SimpleDirectedGraphBuilder {
+impl GraphBuilderBase for SimpleDirectedGraphBuilder {
+    type GraphType = SimpleDirectedGraph;
+
     // builds a graph from a vector of IDs. Repeated edges are ignored.
     #[allow(clippy::ptr_arg)]
-    pub fn from_vector(data: &Vec<(i64, i64)>) -> SimpleDirectedGraph {
+    fn from_vector(data: &Vec<(i64, i64)>) -> SimpleDirectedGraph {
         let mut ids: BTreeMap<NodeId, (BTreeSet<NodeId>, BTreeSet<NodeId>)> = BTreeMap::new();
         for (id1, id2) in data {
             ids.entry(NodeId::from(*id1))

--- a/src/dachshund/simple_transformer.rs
+++ b/src/dachshund/simple_transformer.rs
@@ -14,6 +14,7 @@ use crate::dachshund::coreness::Coreness;
 use crate::dachshund::eigenvector_centrality::EigenvectorCentrality;
 use crate::dachshund::error::CLQResult;
 use crate::dachshund::graph_base::GraphBase;
+use crate::dachshund::graph_builder_base::GraphBuilderBase;
 use crate::dachshund::id_types::{GraphId, NodeId};
 use crate::dachshund::line_processor::{LineProcessor, LineProcessorBase};
 use crate::dachshund::row::{Row, SimpleEdgeRow};

--- a/src/dachshund/simple_undirected_graph.rs
+++ b/src/dachshund/simple_undirected_graph.rs
@@ -69,6 +69,12 @@ impl GraphBase for SimpleUndirectedGraph {
     fn count_nodes(&self) -> usize {
         self.nodes.len()
     }
+    fn create_empty() -> Self {
+        SimpleUndirectedGraph {
+            nodes: HashMap::new(),
+            ids: Vec::new(),
+        }
+    }
 }
 impl SimpleUndirectedGraph {
     pub fn as_input_rows(&self, graph_id: usize) -> String {
@@ -89,12 +95,6 @@ impl SimpleUndirectedGraph {
     }
     pub fn get_node_degree(&self, id: NodeId) -> usize {
         self.nodes[&id].degree()
-    }
-    pub fn create_empty() -> Self {
-        Self {
-            nodes: HashMap::new(),
-            ids: Vec::new(),
-        }
     }
 }
 impl UndirectedGraph for SimpleUndirectedGraph {}

--- a/src/dachshund/simple_undirected_graph.rs
+++ b/src/dachshund/simple_undirected_graph.rs
@@ -9,10 +9,9 @@ use crate::dachshund::algebraic_connectivity::AlgebraicConnectivity;
 use crate::dachshund::betweenness::Betweenness;
 use crate::dachshund::clustering::Clustering;
 use crate::dachshund::cnm_communities::CNMCommunities;
-use crate::dachshund::connected_components::{
-  ConnectedComponents, ConnectedComponentsUndirected
-};
+use crate::dachshund::connected_components::{ConnectedComponents, ConnectedComponentsUndirected};
 use crate::dachshund::connectivity::Connectivity;
+use crate::dachshund::connectivity::ConnectivityUndirected;
 use crate::dachshund::coreness::Coreness;
 use crate::dachshund::eigenvector_centrality::EigenvectorCentrality;
 use crate::dachshund::graph_base::GraphBase;
@@ -25,8 +24,10 @@ use std::collections::hash_map::{Keys, Values};
 use std::collections::HashMap;
 
 pub trait UndirectedGraph
-where Self: GraphBase  
-{}
+where
+    Self: GraphBase,
+{
+}
 /// Keeps track of a simple undirected graph, composed of nodes without any type information.
 pub struct SimpleUndirectedGraph {
     pub nodes: HashMap<NodeId, SimpleNode>,
@@ -104,9 +105,10 @@ impl ConnectedComponentsUndirected for SimpleUndirectedGraph {}
 impl Coreness for SimpleUndirectedGraph {}
 
 impl AdjacencyMatrix for SimpleUndirectedGraph {}
-impl Betweenness for SimpleUndirectedGraph {}
 impl Clustering for SimpleUndirectedGraph {}
 impl Connectivity for SimpleUndirectedGraph {}
+impl ConnectivityUndirected for SimpleUndirectedGraph {}
+impl Betweenness for SimpleUndirectedGraph {}
 impl Laplacian for SimpleUndirectedGraph {}
 impl Transitivity for SimpleUndirectedGraph {}
 impl ShortestPaths for SimpleUndirectedGraph {}

--- a/src/dachshund/simple_undirected_graph_builder.rs
+++ b/src/dachshund/simple_undirected_graph_builder.rs
@@ -4,46 +4,15 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-extern crate nalgebra as na;
+use crate::dachshund::graph_builder_base::GraphBuilderBase;
 use crate::dachshund::id_types::NodeId;
 use crate::dachshund::node::SimpleNode;
 use crate::dachshund::simple_undirected_graph::SimpleUndirectedGraph;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use rand::prelude::*;
-
 pub struct SimpleUndirectedGraphBuilder {}
-
 impl SimpleUndirectedGraphBuilder {
-    // builds a graph from a vector of IDs. Repeated edges are ignored.
-    // Edges only need to be provided once (this being an undirected graph)
-    #[allow(clippy::ptr_arg)]
-    pub fn from_vector(data: &Vec<(i64, i64)>) -> SimpleUndirectedGraph {
-        let mut ids: BTreeMap<NodeId, BTreeSet<NodeId>> = BTreeMap::new();
-        for (id1, id2) in data {
-            ids.entry(NodeId::from(*id1))
-                .or_insert_with(BTreeSet::new)
-                .insert(NodeId::from(*id2));
-            ids.entry(NodeId::from(*id2))
-                .or_insert_with(BTreeSet::new)
-                .insert(NodeId::from(*id1));
-        }
-        let mut nodes: HashMap<NodeId, SimpleNode> = HashMap::new();
-        for (id, neighbors) in ids.into_iter() {
-            nodes.insert(
-                id,
-                SimpleNode {
-                    node_id: id,
-                    neighbors: neighbors,
-                },
-            );
-        }
-        SimpleUndirectedGraph {
-            ids: nodes.keys().cloned().collect(),
-            nodes,
-        }
-    }
-
     // Build a graph with n vertices with every possible edge.
     pub fn get_complete_graph(n: u64) -> SimpleUndirectedGraph {
         let mut v = Vec::new();
@@ -105,4 +74,38 @@ impl SimpleUndirectedGraphBuilder {
             &v.into_iter().map(|(x, y)| (x as i64, y as i64)).collect(),
         )
     }
+}
+impl GraphBuilderBase for SimpleUndirectedGraphBuilder {
+
+    type GraphType = SimpleUndirectedGraph;
+
+    // builds a graph from a vector of IDs. Repeated edges are ignored.
+    // Edges only need to be provided once (this being an undirected graph)
+    #[allow(clippy::ptr_arg)]
+    fn from_vector(data: &Vec<(i64, i64)>) -> SimpleUndirectedGraph {
+        let mut ids: BTreeMap<NodeId, BTreeSet<NodeId>> = BTreeMap::new();
+        for (id1, id2) in data {
+            ids.entry(NodeId::from(*id1))
+                .or_insert_with(BTreeSet::new)
+                .insert(NodeId::from(*id2));
+            ids.entry(NodeId::from(*id2))
+                .or_insert_with(BTreeSet::new)
+                .insert(NodeId::from(*id1));
+        }
+        let mut nodes: HashMap<NodeId, SimpleNode> = HashMap::new();
+        for (id, neighbors) in ids.into_iter() {
+            nodes.insert(
+                id,
+                SimpleNode {
+                    node_id: id,
+                    neighbors: neighbors,
+                },
+            );
+        }
+        SimpleUndirectedGraph {
+            ids: nodes.keys().cloned().collect(),
+            nodes,
+        }
+    }
+
 }

--- a/src/dachshund/typed_graph.rs
+++ b/src/dachshund/typed_graph.rs
@@ -56,4 +56,11 @@ impl GraphBase for TypedGraph {
     fn count_nodes(&self) -> usize {
         self.nodes.len()
     }
+    fn create_empty() -> Self {
+        TypedGraph {
+            nodes: HashMap::new(),
+            core_ids: Vec::new(),
+            non_core_ids: Vec::new(),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub use dachshund::coreness::Coreness;
 pub use dachshund::eigenvector_centrality::EigenvectorCentrality;
 pub use dachshund::graph_base::GraphBase;
 pub use dachshund::graph_builder::GraphBuilder;
+pub use dachshund::graph_builder_base::GraphBuilderBase;
 pub use dachshund::id_types::{EdgeTypeId, GraphId, NodeId, NodeTypeId};
 pub use dachshund::input::Input;
 pub use dachshund::laplacian::Laplacian;

--- a/tests/cnm.rs
+++ b/tests/cnm.rs
@@ -6,6 +6,7 @@
  */
 extern crate lib_dachshund;
 use lib_dachshund::dachshund::cnm_communities::CNMCommunities;
+use lib_dachshund::dachshund::graph_builder_base::GraphBuilderBase;
 use lib_dachshund::dachshund::simple_undirected_graph::SimpleUndirectedGraph;
 use lib_dachshund::dachshund::simple_undirected_graph_builder::SimpleUndirectedGraphBuilder;
 

--- a/tests/karate_club.rs
+++ b/tests/karate_club.rs
@@ -17,10 +17,11 @@ use lib_dachshund::dachshund::cnm_communities::CNMCommunities;
 use lib_dachshund::dachshund::connected_components::{
     ConnectedComponentsDirected, ConnectedComponentsUndirected,
 };
-use lib_dachshund::dachshund::connectivity::ConnectivityUndirected;
+use lib_dachshund::dachshund::connectivity::{ConnectivityUndirected, ConnectivityDirected};
 use lib_dachshund::dachshund::coreness::Coreness;
 use lib_dachshund::dachshund::eigenvector_centrality::EigenvectorCentrality;
 use lib_dachshund::dachshund::graph_base::GraphBase;
+use lib_dachshund::dachshund::graph_builder_base::GraphBuilderBase;
 use lib_dachshund::dachshund::id_types::NodeId;
 use lib_dachshund::dachshund::laplacian::Laplacian;
 use lib_dachshund::dachshund::shortest_paths::ShortestPaths;
@@ -114,15 +115,22 @@ fn get_karate_club_edges() -> Vec<(usize, usize)> {
         (33, 34),
     ]
 }
-fn get_karate_club_graph_with_one_extra_edge() -> SimpleUndirectedGraph {
+fn _get_karate_club_graph_with_one_extra_edge<T, R>() -> R
+where R: GraphBase, T: GraphBuilderBase<GraphType = R> {
     let mut rows = get_karate_club_edges();
     rows.push((35, 36));
-    SimpleUndirectedGraphBuilder::from_vector(
+    T::from_vector(
         &rows
             .into_iter()
             .map(|(x, y)| (x as i64, y as i64))
             .collect(),
     )
+}
+fn get_karate_club_graph_with_one_extra_edge() -> SimpleUndirectedGraph {
+    _get_karate_club_graph_with_one_extra_edge::<SimpleUndirectedGraphBuilder, _>()
+}
+fn get_directed_karate_club_graph_with_one_extra_edge() -> SimpleDirectedGraph {
+    _get_karate_club_graph_with_one_extra_edge::<SimpleDirectedGraphBuilder, _>()
 }
 
 fn get_two_karate_clubs_edges() -> Vec<(usize, usize)> {
@@ -133,20 +141,39 @@ fn get_two_karate_clubs_edges() -> Vec<(usize, usize)> {
     rows
 }
 
-fn get_two_karate_clubs() -> SimpleUndirectedGraph {
+fn _get_two_karate_clubs<T, R>() -> R
+where R: GraphBase, T: GraphBuilderBase<GraphType = R> {
     let rows = get_two_karate_clubs_edges();
-    SimpleUndirectedGraphBuilder::from_vector(
+    T::from_vector(
         &rows
             .into_iter()
             .map(|(x, y)| (x as i64, y as i64))
             .collect(),
     )
 }
+fn get_two_karate_clubs() -> SimpleUndirectedGraph {
+    _get_two_karate_clubs::<SimpleUndirectedGraphBuilder, _>()
+}
 
-fn get_two_karate_clubs_with_bridge() -> SimpleUndirectedGraph {
+fn _get_two_karate_clubs_with_bridge<T, R>() -> R
+where R: GraphBase, T: GraphBuilderBase<GraphType = R> {
     let mut rows = get_two_karate_clubs_edges();
     rows.push((34, 35));
-    SimpleUndirectedGraphBuilder::from_vector(
+    T::from_vector(
+        &rows
+            .into_iter()
+            .map(|(x, y)| (x as i64, y as i64))
+            .collect(),
+    )
+}
+fn get_two_karate_clubs_with_bridge() -> SimpleUndirectedGraph {
+    _get_two_karate_clubs_with_bridge::<SimpleUndirectedGraphBuilder, _>()
+}
+
+fn _get_karate_club_graph<T, R>() -> R
+where R: GraphBase, T: GraphBuilderBase<GraphType = R> {
+    let rows = get_karate_club_edges();
+    T::from_vector(
         &rows
             .into_iter()
             .map(|(x, y)| (x as i64, y as i64))
@@ -154,22 +181,10 @@ fn get_two_karate_clubs_with_bridge() -> SimpleUndirectedGraph {
     )
 }
 fn get_karate_club_graph() -> SimpleUndirectedGraph {
-    let rows = get_karate_club_edges();
-    SimpleUndirectedGraphBuilder::from_vector(
-        &rows
-            .into_iter()
-            .map(|(x, y)| (x as i64, y as i64))
-            .collect(),
-    )
+    _get_karate_club_graph::<SimpleUndirectedGraphBuilder, _>()
 }
 fn get_directed_karate_club_graph() -> SimpleDirectedGraph {
-    let rows = get_karate_club_edges();
-    SimpleDirectedGraphBuilder::from_vector(
-        &rows
-            .into_iter()
-            .map(|(x, y)| (x as i64, y as i64))
-            .collect(),
-    )
+    _get_karate_club_graph::<SimpleDirectedGraphBuilder, _>()
 }
 
 #[cfg(test)]
@@ -552,4 +567,16 @@ fn test_weakly_connected_components() {
     let cc = gd.get_weakly_connected_components();
     assert_eq!(cc[0].len(), 34);
     assert_eq!(cc.len(), 1);
+}
+#[test]
+fn test_connectivity_directed() {
+    let graph = get_directed_karate_club_graph();
+    assert!(graph.get_is_weakly_connected().unwrap());
+    let graph_unconnected = get_directed_karate_club_graph_with_one_extra_edge();
+    assert!(!graph_unconnected.get_is_weakly_connected().unwrap());
+
+    let graph_empty = SimpleDirectedGraph::create_empty();
+    assert!(graph_empty.get_is_weakly_connected().is_err(), "Graph is empty");
+
+    assert!(graph.get_is_weakly_connected().unwrap());
 }

--- a/tests/karate_club.rs
+++ b/tests/karate_club.rs
@@ -15,9 +15,9 @@ use lib_dachshund::dachshund::brokerage::Brokerage;
 use lib_dachshund::dachshund::clustering::Clustering;
 use lib_dachshund::dachshund::cnm_communities::CNMCommunities;
 use lib_dachshund::dachshund::connected_components::{
-    ConnectedComponentsDirected, ConnectedComponentsUndirected
+    ConnectedComponentsDirected, ConnectedComponentsUndirected,
 };
-use lib_dachshund::dachshund::connectivity::Connectivity;
+use lib_dachshund::dachshund::connectivity::ConnectivityUndirected;
 use lib_dachshund::dachshund::coreness::Coreness;
 use lib_dachshund::dachshund::eigenvector_centrality::EigenvectorCentrality;
 use lib_dachshund::dachshund::graph_base::GraphBase;
@@ -476,7 +476,6 @@ fn test_cnm_community() {
 
 #[test]
 fn test_brokerage() {
-   
     let expected_counts = vec![
         (0, 0, 0, 0, 0, 0),
         (0, 0, 0, 0, 0, 0),
@@ -512,35 +511,44 @@ fn test_brokerage() {
         (0, 0, 0, 2, 0, 2),
         (5, 0, 0, 2, 0, 7),
         (0, 0, 0, 1, 0, 1),
-        (0, 0, 0, 0, 0, 0), 
+        (0, 0, 0, 0, 0, 0),
     ];
-    let g = get_directed_karate_club_graph(); 
+    let g = get_directed_karate_club_graph();
     let mut c: HashMap<NodeId, usize> = HashMap::new();
     for node_id in g.get_ids_iter() {
         c.insert(*node_id, 1 + ((node_id.value() <= 17) as usize));
     }
     for node_id in g.get_ids_iter() {
-        let scores = g.get_brokerage_scores_for_node(
-            *node_id, &c
+        let scores = g.get_brokerage_scores_for_node(*node_id, &c);
+        assert_eq!(
+            scores.total_open_twopaths,
+            expected_counts[node_id.value() as usize].5
         );
-        assert_eq!(scores.total_open_twopaths,
-                   expected_counts[node_id.value() as usize].5);
-        assert_eq!(scores.num_coordinator_ties, 
-                   expected_counts[node_id.value() as usize].0);
-        assert_eq!(scores.num_itinerant_broker_ties, 
-                   expected_counts[node_id.value() as usize].1);
-        assert_eq!(scores.num_representative_ties, 
-                   expected_counts[node_id.value() as usize].2);
-        assert_eq!(scores.num_gatekeeper_ties, 
-                   expected_counts[node_id.value() as usize].3);
-        assert_eq!(scores.num_liaison_ties, 
-                   expected_counts[node_id.value() as usize].4);
-        
-    };
+        assert_eq!(
+            scores.num_coordinator_ties,
+            expected_counts[node_id.value() as usize].0
+        );
+        assert_eq!(
+            scores.num_itinerant_broker_ties,
+            expected_counts[node_id.value() as usize].1
+        );
+        assert_eq!(
+            scores.num_representative_ties,
+            expected_counts[node_id.value() as usize].2
+        );
+        assert_eq!(
+            scores.num_gatekeeper_ties,
+            expected_counts[node_id.value() as usize].3
+        );
+        assert_eq!(
+            scores.num_liaison_ties,
+            expected_counts[node_id.value() as usize].4
+        );
+    }
 }
 #[test]
 fn test_weakly_connected_components() {
-    let gd = get_directed_karate_club_graph(); 
+    let gd = get_directed_karate_club_graph();
     let cc = gd.get_weakly_connected_components();
     assert_eq!(cc[0].len(), 34);
     assert_eq!(cc.len(), 1);

--- a/tests/simple_directed_graph.rs
+++ b/tests/simple_directed_graph.rs
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 extern crate lib_dachshund;
+use lib_dachshund::dachshund::graph_builder_base::GraphBuilderBase;
 use lib_dachshund::dachshund::graph_base::GraphBase;
 use lib_dachshund::dachshund::simple_directed_graph::SimpleDirectedGraph;
 use lib_dachshund::dachshund::simple_directed_graph_builder::SimpleDirectedGraphBuilder;

--- a/tests/simple_graph.rs
+++ b/tests/simple_graph.rs
@@ -8,7 +8,7 @@ extern crate lib_dachshund;
 use crate::lib_dachshund::TransformerBase;
 use lib_dachshund::dachshund::cnm_communities::CNMCommunities;
 use lib_dachshund::dachshund::connected_components::{
-    ConnectedComponentsUndirected, ConnectedComponents
+    ConnectedComponents, ConnectedComponentsUndirected,
 };
 use lib_dachshund::dachshund::coreness::Coreness;
 use lib_dachshund::dachshund::id_types::NodeId;

--- a/tests/simple_graph.rs
+++ b/tests/simple_graph.rs
@@ -11,6 +11,7 @@ use lib_dachshund::dachshund::connected_components::{
     ConnectedComponents, ConnectedComponentsUndirected,
 };
 use lib_dachshund::dachshund::coreness::Coreness;
+use lib_dachshund::dachshund::graph_builder_base::GraphBuilderBase;
 use lib_dachshund::dachshund::id_types::NodeId;
 use lib_dachshund::dachshund::input::Input;
 use lib_dachshund::dachshund::output::Output;

--- a/tests/triangles.rs
+++ b/tests/triangles.rs
@@ -10,6 +10,7 @@ extern crate lib_dachshund;
 extern crate test;
 
 use lib_dachshund::dachshund::clustering::Clustering;
+use lib_dachshund::dachshund::graph_builder_base::GraphBuilderBase;
 use lib_dachshund::dachshund::id_types::NodeId;
 use lib_dachshund::dachshund::simple_undirected_graph::SimpleUndirectedGraph;
 use lib_dachshund::dachshund::simple_undirected_graph_builder::SimpleUndirectedGraphBuilder;


### PR DESCRIPTION
Implemented `ConnectivityDirected`, to check whether a directed graph is in fact connected. This diff also showcases how we can unify code that is *mostly* the same, e.g. node traversals, where we might want to traverse a directed graph using different logic than an undirected graph (e.g. for Kosaraju's algorithm).