### PR TITLE
Added test for whether a directed graph is acyclic

### DIFF
--- a/src/dachshund/connectivity.rs
+++ b/src/dachshund/connectivity.rs
@@ -6,7 +6,7 @@
  */
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
-use crate::dachshund::node::{NodeBase, NodeEdgeBase};
+use crate::dachshund::node::{DirectedNodeBase, NodeBase, NodeEdgeBase};
 use crate::dachshund::simple_directed_graph::DirectedGraph;
 use crate::dachshund::simple_undirected_graph::UndirectedGraph;
 use std::collections::BTreeSet;
@@ -70,6 +70,7 @@ pub trait ConnectivityDirected: GraphBase
 where
     Self: Connectivity,
     Self: DirectedGraph,
+    <Self as GraphBase>::NodeType: DirectedNodeBase
 {
     fn get_is_weakly_connected(&self) -> Result<bool, &'static str> {
         self._get_is_connected(Self::NodeType::get_edges)

--- a/src/dachshund/node.rs
+++ b/src/dachshund/node.rs
@@ -194,6 +194,16 @@ pub trait DirectedNodeBase: NodeBase {
     fn has_out_neighbor(&self, nid: NodeId) -> bool;
     fn get_in_degree(&self) -> usize;
     fn get_out_degree(&self) -> usize;
+    // used to determine if the node is a leaf
+    fn has_no_out_neighbors_except_set(&self, exclude_set: &HashSet<NodeId>) -> bool {
+        for e in self.get_out_neighbors() {
+            let nid = e.get_neighbor_id();
+            if !exclude_set.contains(&nid) {
+                return false;
+            }
+        }
+        true
+    }
 }
 pub struct SimpleDirectedNode {
     pub node_id: NodeId,

--- a/src/dachshund/simple_directed_graph.rs
+++ b/src/dachshund/simple_directed_graph.rs
@@ -11,12 +11,14 @@ use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
 use crate::dachshund::node::{NodeBase, SimpleDirectedNode};
 use std::collections::hash_map::{Keys, Values};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use crate::dachshund::node::DirectedNodeBase;
 
 pub trait DirectedGraph
 where
     Self: GraphBase,
 {
+    fn is_acyclic(&self) -> bool;
 }
 pub struct SimpleDirectedGraph {
     pub nodes: HashMap<NodeId, SimpleDirectedNode>,
@@ -66,7 +68,26 @@ impl GraphBase for SimpleDirectedGraph {
         }
     }
 }
-impl DirectedGraph for SimpleDirectedGraph {}
+impl DirectedGraph for SimpleDirectedGraph {
+    fn is_acyclic(&self) -> bool {
+        // from https://www.cs.hmc.edu/~keller/courses/cs60/s98/examples/acyclic/
+        let mut leaves: HashSet<NodeId> = HashSet::new();
+        let num_nodes = self.count_nodes();
+        while leaves.len() < num_nodes {
+            let mut leaf_was_found: bool = false;
+            for node in self.get_nodes_iter() {
+                if node.has_no_out_neighbors_except_set(&leaves) {
+                    leaves.insert(node.get_id());
+                    leaf_was_found = true;
+                }
+            }
+            if !leaf_was_found {
+                return false;
+            }
+        }
+        return true;
+    }
+}
 impl Brokerage for SimpleDirectedGraph {}
 impl ConnectedComponents for SimpleDirectedGraph {}
 impl ConnectedComponentsDirected for SimpleDirectedGraph {}

--- a/src/dachshund/simple_directed_graph.rs
+++ b/src/dachshund/simple_directed_graph.rs
@@ -9,16 +9,33 @@ use crate::dachshund::connected_components::{ConnectedComponents, ConnectedCompo
 use crate::dachshund::connectivity::{Connectivity, ConnectivityDirected};
 use crate::dachshund::graph_base::GraphBase;
 use crate::dachshund::id_types::NodeId;
-use crate::dachshund::node::{NodeBase, SimpleDirectedNode};
+use crate::dachshund::node::{DirectedNodeBase, NodeBase, SimpleDirectedNode};
 use std::collections::hash_map::{Keys, Values};
 use std::collections::{HashMap, HashSet};
-use crate::dachshund::node::DirectedNodeBase;
 
 pub trait DirectedGraph
 where
     Self: GraphBase,
+    <Self as GraphBase>::NodeType: DirectedNodeBase
 {
-    fn is_acyclic(&self) -> bool;
+    fn is_acyclic(&self) -> bool {
+        // from https://www.cs.hmc.edu/~keller/courses/cs60/s98/examples/acyclic/
+        let mut leaves: HashSet<NodeId> = HashSet::new();
+        let num_nodes = self.count_nodes();
+        while leaves.len() < num_nodes {
+            let mut leaf_was_found: bool = false;
+            for node in self.get_nodes_iter() {
+                if node.has_no_out_neighbors_except_set(&leaves) {
+                    leaves.insert(node.get_id());
+                    leaf_was_found = true;
+                }
+            }
+            if !leaf_was_found {
+                return false;
+            }
+        }
+        return true;
+    }
 }
 pub struct SimpleDirectedGraph {
     pub nodes: HashMap<NodeId, SimpleDirectedNode>,
@@ -68,26 +85,7 @@ impl GraphBase for SimpleDirectedGraph {
         }
     }
 }
-impl DirectedGraph for SimpleDirectedGraph {
-    fn is_acyclic(&self) -> bool {
-        // from https://www.cs.hmc.edu/~keller/courses/cs60/s98/examples/acyclic/
-        let mut leaves: HashSet<NodeId> = HashSet::new();
-        let num_nodes = self.count_nodes();
-        while leaves.len() < num_nodes {
-            let mut leaf_was_found: bool = false;
-            for node in self.get_nodes_iter() {
-                if node.has_no_out_neighbors_except_set(&leaves) {
-                    leaves.insert(node.get_id());
-                    leaf_was_found = true;
-                }
-            }
-            if !leaf_was_found {
-                return false;
-            }
-        }
-        return true;
-    }
-}
+impl DirectedGraph for SimpleDirectedGraph {}
 impl Brokerage for SimpleDirectedGraph {}
 impl ConnectedComponents for SimpleDirectedGraph {}
 impl ConnectedComponentsDirected for SimpleDirectedGraph {}

--- a/src/dachshund/simple_directed_graph.rs
+++ b/src/dachshund/simple_directed_graph.rs
@@ -25,7 +25,8 @@ where
         while leaves.len() < num_nodes {
             let mut leaf_was_found: bool = false;
             for node in self.get_nodes_iter() {
-                if node.has_no_out_neighbors_except_set(&leaves) {
+                let node_id = node.get_id();
+                if !leaves.contains(&node_id) && node.has_no_out_neighbors_except_set(&leaves) {
                     leaves.insert(node.get_id());
                     leaf_was_found = true;
                 }

--- a/tests/karate_club.rs
+++ b/tests/karate_club.rs
@@ -26,7 +26,7 @@ use lib_dachshund::dachshund::id_types::NodeId;
 use lib_dachshund::dachshund::node::DirectedNodeBase;
 use lib_dachshund::dachshund::laplacian::Laplacian;
 use lib_dachshund::dachshund::shortest_paths::ShortestPaths;
-use lib_dachshund::dachshund::simple_directed_graph::SimpleDirectedGraph;
+use lib_dachshund::dachshund::simple_directed_graph::{DirectedGraph, SimpleDirectedGraph};
 use lib_dachshund::dachshund::simple_directed_graph_builder::SimpleDirectedGraphBuilder;
 use lib_dachshund::dachshund::simple_undirected_graph::SimpleUndirectedGraph;
 use lib_dachshund::dachshund::simple_undirected_graph_builder::SimpleUndirectedGraphBuilder;
@@ -618,4 +618,21 @@ fn test_connectivity_directed() {
     assert!(scc[0].iter().collect::<HashSet<&NodeId>>().contains(&NodeId::from(1)));
     assert!(scc[0].iter().collect::<HashSet<&NodeId>>().contains(&NodeId::from(2)));
     assert!(scc[0].iter().collect::<HashSet<&NodeId>>().contains(&NodeId::from(3)));
+}
+#[test]
+fn test_acyclic_directed() {
+    let graph = get_directed_karate_club_graph();
+    assert!(graph.is_acyclic());
+    let graph_unconnected = get_directed_karate_club_graph_with_one_extra_edge();
+    assert!(graph_unconnected.is_acyclic());
+
+    let graph_empty = SimpleDirectedGraph::create_empty();
+    assert!(graph_empty.is_acyclic());
+
+    let graph_both_ways = get_directed_karate_club_graph_both_ways();
+    assert!(!graph_both_ways.is_acyclic());
+
+    let core = vec![1, 2, 3];
+    let graph_with_core = get_directed_karate_club_graph_with_core(core.into_iter().collect::<HashSet<usize>>());
+    assert!(!graph_with_core.is_acyclic());
 }


### PR DESCRIPTION
Straightforward algorithm: keep removing leaves until there are either no leaves left (case in which graph is cyclic) or until there are no nodes left (case in which graph is acyclic). This test should be implemented as part of the constructor for a `DirectedAcyclicGraphBase` trait (coming soon).